### PR TITLE
Check APNS return code

### DIFF
--- a/spec/apns_dispatch/apn_notification_spec.rb
+++ b/spec/apns_dispatch/apn_notification_spec.rb
@@ -11,11 +11,24 @@ describe ApnsDispatch::ApnNotification do
     expected_message = { aps: { alert: message, sound: 'default', badge: 1}, order_id: 1}
     payload = expected_message.to_json
     @packet = [0, 32, [token].pack('H*'), payload.bytesize, payload].pack('cna*na*')
+    @success_status_packet = [8, 0, 0].pack('CCN')
+    @error_status_packet = [8, 255, 0].pack('CCN') # Unknown APNS error code: 255
   end
 
-  it 'sends a notification packet to the connection' do
+  it 'sends a notification packet to the connection and reads the status' do
     @connection.should_receive(:write).with(@packet)
+    @connection.should_receive(:read).with(@success_status_packet.size) { @success_status_packet }
 
-    @apn_notificiation.send_notification
+    result = @apn_notificiation.send_notification
+    result.should eq(true)
+  end
+
+  it 'sends a notification packet to the connection and disconnects on error' do
+    @connection.should_receive(:write).with(@packet)
+    @connection.should_receive(:read).with(@error_status_packet.size) { @error_status_packet }
+    @connection.should_receive(:disconnect!)
+
+    result = @apn_notificiation.send_notification
+    result.should eq(false)
   end
 end


### PR DESCRIPTION
Some APNS return codes cause a connection to stop accepting new notifications. The documentation states that error 255 does this but the is anecdotal evidence that some other may cause it as well. This change causes a `connection#disconnect!` if a send fails. This could be made to only disconnect on error 255 but I took the more conservative approach.
