### PR TITLE
Strip nil values before to_json to save bytes in payload

### DIFF
--- a/lib/apns_dispatch/apn_notification.rb
+++ b/lib/apns_dispatch/apn_notification.rb
@@ -38,7 +38,10 @@ module ApnsDispatch
     end
 
     def payload
-      message_information.to_json
+      # strip out nil values in :aps and root space to save bytes
+      Hash[message_information.reject { |k,v| v.nil? }.map do |k,v|
+        [k, v.kind_of?(Hash) ? v.reject { |k,v| v.nil? } : v]
+      end].to_json
     end
   end
 end

--- a/spec/apns_dispatch/apn_notification_spec.rb
+++ b/spec/apns_dispatch/apn_notification_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ApnsDispatch::ApnNotification do
-  before do
+  it 'sends a notification packet to the connection' do
     token = '7307dea69c58e9625250aabb040594e1a031f574dba5d97549fbe211327aff4c'
     message = 'test message'
     options = { aps: { badge: 1 }, order_id: 1 }
@@ -11,9 +11,23 @@ describe ApnsDispatch::ApnNotification do
     expected_message = { aps: { alert: message, sound: 'default', badge: 1}, order_id: 1}
     payload = expected_message.to_json
     @packet = [0, 32, [token].pack('H*'), payload.bytesize, payload].pack('cna*na*')
+
+    @connection.should_receive(:write).with(@packet)
+
+    @apn_notificiation.send_notification
   end
 
-  it 'sends a notification packet to the connection' do
+  it 'strips nil values' do
+    token = '7307dea69c58e9625250aabb040594e1a031f574dba5d97549fbe211327aff4c'
+    message = 'test message'
+    options = { aps: { badge: 1, :sound => nil }, order_id: 1 }
+    @connection = stub
+    @apn_notificiation = ApnsDispatch::ApnNotification.new(@connection, token, message, options)
+
+    expected_message = { aps: { alert: message, badge: 1}, order_id: 1}
+    payload = expected_message.to_json
+    @packet = [0, 32, [token].pack('H*'), payload.bytesize, payload].pack('cna*na*')
+
     @connection.should_receive(:write).with(@packet)
 
     @apn_notificiation.send_notification


### PR DESCRIPTION
This is a small change that gives a little more room for alert text in notifications with nil keys (especially silent notifications with no sound). Previously, the json would include `"sound":null,`. This change omits the key if it's nil, so you gain back those characters to apply to alert text.

Thanks for the gem, this works great!