### PR TITLE
Add notice about gem retirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This project is unmaintained.** We recommend using a library compatible with Apple's newer [HTTP/2-based API](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1), such as [apnotic](https://github.com/ostinelli/apnotic).
+
 # ApnsDispatch
 
 A simple Ruby framework for sending push notifications and receiving feedback using the Apple Push Notification service


### PR DESCRIPTION
I think it's time to archive this repository as read-only, but I'd first like to add a notice to the README for anyone who stumbles across it.